### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/benchmark/Start.java
+++ b/src/benchmark/Start.java
@@ -169,6 +169,7 @@ public class Start {
             Thread.sleep(1000L * 2);
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
         System.out.println();
     }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).