### PR TITLE
add timeout support for shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>cn.danielw</groupId>
 	<artifactId>fast-object-pool</artifactId>
 	<packaging>jar</packaging>
-	<version>2.1.2</version>
+	<version>2.2.0</version>
 	<description>An extremely fast object pool with zero dependencies</description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/cn/danielw/fop/ObjectPoolPartition.java
+++ b/src/main/java/cn/danielw/fop/ObjectPoolPartition.java
@@ -94,7 +94,8 @@ public class ObjectPoolPartition<T> {
 
     public synchronized int shutdown() {
         int removed = 0;
-        while (this.totalCount > 0) {
+        long startTs = System.currentTimeMillis();
+        while (this.totalCount > 0 && System.currentTimeMillis() - startTs < config.getShutdownWaitMilliseconds()) {
             Poolable<T> obj = objectQueue.poll();
             if (obj != null) {
                 decreaseObject(obj);

--- a/src/main/java/cn/danielw/fop/PoolConfig.java
+++ b/src/main/java/cn/danielw/fop/PoolConfig.java
@@ -109,8 +109,9 @@ public class PoolConfig {
     /**
      * If any borrowed objects are leaked and cannot be returned, the pool will be shut down after
      * <code>partitions * shutdownWaitMilliseconds</code> milliseconds.
-     * If any borrowed objects are in use and cannot be returned to the pool timely,
-     * the pool will be shut down with leaked objects.
+     * If any borrowed objects are in use and cannot be returned to the pool timely
+     * within <code>partitions * shutdownWaitMilliseconds</code> milliseconds,
+     * the pool will be shut down and the objects in use will not be returned.
      * @param shutdownWaitMilliseconds default to 30 seconds for each partition
      */
     public void setShutdownWaitMilliseconds(int shutdownWaitMilliseconds) {

--- a/src/main/java/cn/danielw/fop/PoolConfig.java
+++ b/src/main/java/cn/danielw/fop/PoolConfig.java
@@ -12,7 +12,7 @@ public class PoolConfig {
     private int partitionSize = 4;
     private int scavengeIntervalMilliseconds = 1000 * 60 * 2;
     private double scavengeRatio = 0.5; // avoid cleaning up all connections in the pool at the same time
-    private long shutdownWaitMilliseconds = 1000 * 30;
+    private int shutdownWaitMilliseconds = 1000 * 30;
 
     public int getMaxWaitMilliseconds() {
         return maxWaitMilliseconds;
@@ -102,7 +102,7 @@ public class PoolConfig {
         return this;
     }
 
-    public long getShutdownWaitMilliseconds() {
+    public int getShutdownWaitMilliseconds() {
         return shutdownWaitMilliseconds;
     }
 
@@ -113,7 +113,7 @@ public class PoolConfig {
      * the pool will be shut down with leaked objects.
      * @param shutdownWaitMilliseconds default to 30 seconds for each partition
      */
-    public void setShutdownWaitMilliseconds(long shutdownWaitMilliseconds) {
+    public void setShutdownWaitMilliseconds(int shutdownWaitMilliseconds) {
         this.shutdownWaitMilliseconds = shutdownWaitMilliseconds;
     }
 }

--- a/src/main/java/cn/danielw/fop/PoolConfig.java
+++ b/src/main/java/cn/danielw/fop/PoolConfig.java
@@ -12,6 +12,7 @@ public class PoolConfig {
     private int partitionSize = 4;
     private int scavengeIntervalMilliseconds = 1000 * 60 * 2;
     private double scavengeRatio = 0.5; // avoid cleaning up all connections in the pool at the same time
+    private long shutdownWaitMilliseconds = 1000 * 30;
 
     public int getMaxWaitMilliseconds() {
         return maxWaitMilliseconds;
@@ -99,5 +100,20 @@ public class PoolConfig {
         }
         this.scavengeRatio = scavengeRatio;
         return this;
+    }
+
+    public long getShutdownWaitMilliseconds() {
+        return shutdownWaitMilliseconds;
+    }
+
+    /**
+     * If any borrowed objects are leaked and cannot be returned, the pool will be shut down after
+     * <code>partitions * shutdownWaitMilliseconds</code> milliseconds.
+     * If any borrowed objects are in use and cannot be returned to the pool timely,
+     * the pool will be shut down with leaked objects.
+     * @param shutdownWaitMilliseconds default to 30 seconds for each partition
+     */
+    public void setShutdownWaitMilliseconds(long shutdownWaitMilliseconds) {
+        this.shutdownWaitMilliseconds = shutdownWaitMilliseconds;
     }
 }


### PR DESCRIPTION
Yes, doable.

the pros:
     * If any borrowed objects are leaked and cannot be returned, the pool will be shut down eventually.
    
the cons:
     * If any borrowed objects are in use and cannot be returned to the pool timely, the pool will be shut down with leaked objects.


