### PR TITLE
Permit a zero value for the scavenge interval configuration option

### DIFF
--- a/src/main/java/cn/danielw/fop/PoolConfig.java
+++ b/src/main/java/cn/danielw/fop/PoolConfig.java
@@ -77,9 +77,9 @@ public class PoolConfig {
      * @return the pool config
      */
     public PoolConfig setScavengeIntervalMilliseconds(int scavengeIntervalMilliseconds) {
-        if (scavengeIntervalMilliseconds < 5000) {
+        if (scavengeIntervalMilliseconds != 0 && scavengeIntervalMilliseconds < 5000) {
             throw new IllegalArgumentException("Cannot set interval too short (" + scavengeIntervalMilliseconds +
-                    "), must be at least 5 seconds");
+                    "), must be at least 5 seconds, or zero to disable scavenger");
         }
         this.scavengeIntervalMilliseconds = scavengeIntervalMilliseconds;
         return this;


### PR DESCRIPTION
The JavaDoc says you can set a zero value to disable the scavenger, and the ObjectPool respects this, but `setScavengeIntervalMilliseconds` throws an exception if you try to actually set the interval to zero.

Closes #38