### PR TITLE
Separate init / ObjectPool.init()

### DIFF
--- a/src/main/java/cn/danielw/fop/DisruptorObjectPool.java
+++ b/src/main/java/cn/danielw/fop/DisruptorObjectPool.java
@@ -10,6 +10,10 @@ public class DisruptorObjectPool<T> extends ObjectPool<T> {
         super(poolConfig, objectFactory);
     }
 
+    public DisruptorObjectPool(PoolConfig poolConfig, ObjectFactory<T> objectFactory, boolean init) {
+        super(poolConfig, objectFactory, init);
+    }
+
     @Override
     protected BlockingQueue<Poolable<T>> createBlockingQueue(PoolConfig config) {
         return new DisruptorBlockingQueue<>(config.getMaxSize());

--- a/src/main/java/cn/danielw/fop/ObjectPool.java
+++ b/src/main/java/cn/danielw/fop/ObjectPool.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
  */
 public class ObjectPool<T> {
 
-    protected static final Logger logger = Logger.getLogger(ObjectPool.class.getCanonicalName());
+    private static final Logger logger = Logger.getLogger(ObjectPool.class.getCanonicalName());
 
     protected final PoolConfig config;
     protected final ObjectFactory<T> factory;


### PR DESCRIPTION
ObjectPool.init() allow to initialize partitions after pool creation. It can be used, for example, if you want to have some ObjectFactory witch contains ref of the pool. Like this:
```java
class XObjectFactory implements ObjectFactory<XObject> {
 @Setter
 private ObjectPool<XObject> pool;
 @Override public XObject create() {
   return new XObject(pool); // object requeres pool reference
  }
 ...
}

XObjectFactory factory = new XObjectFactory();
ObjectPool<XObject> pool = new ObjectPool(conf, factory, false); // create pool, but dont init
factory.setPool(pool); // set pool for factory
pool.init(); // fill pool with new objects
```